### PR TITLE
Update to latest bootloader version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,20 +58,21 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.11.0-alpha.0"
-source = "git+https://github.com/rust-osdev/bootloader?rev=960671c#960671c3669c7d1be95f1dfb40afdf9bea8172f8"
+version = "0.11.0-alpha"
+source = "git+https://github.com/rust-osdev/bootloader?branch=next#c78a2f540acce48f805a998070f8cd2368945e75"
 dependencies = [
  "anyhow",
  "fatfs",
  "gpt",
  "llvm-tools",
  "mbrman",
+ "tempfile",
 ]
 
 [[package]]
 name = "bootloader_api"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/rust-osdev/bootloader?rev=960671c#960671c3669c7d1be95f1dfb40afdf9bea8172f8"
+source = "git+https://github.com/rust-osdev/bootloader?branch=next#c78a2f540acce48f805a998070f8cd2368945e75"
 
 [[package]]
 name = "build_const"
@@ -128,6 +129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fatfs"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +190,15 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -286,6 +305,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "runner"
 version = "0.1.0"
 dependencies = [
@@ -303,18 +340,18 @@ checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -339,6 +376,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "test-kernel"
 version = "0.1.0"
 dependencies = [
@@ -349,18 +400,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ features = ["regular", "size_14"]
 
 [patch.crates-io]
 # Change this to the revision of the bootloader you want to test.
-bootloader = { git = "https://github.com/rust-osdev/bootloader", rev = "960671c", package = "bootloader", version = "=0.11.0-alpha.0" }
-bootloader_api = { git = "https://github.com/rust-osdev/bootloader", rev = "960671c", package = "bootloader_api", version = "=0.1.0-alpha.0" }
-
+bootloader = { git = "https://github.com/rust-osdev/bootloader", branch = "next", package = "bootloader", version = "=0.11.0-alpha" }
+bootloader_api = { git = "https://github.com/rust-osdev/bootloader", branch = "next", package = "bootloader_api", version = "=0.1.0-alpha.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,10 @@ members = ["runner"]
 resolver = "2"
 
 [dependencies]
-bootloader_api = "0.1.0-alpha.0"
+bootloader_api = { git = "https://github.com/rust-osdev/bootloader", branch = "next" }
 uart_16550 = "0.2.10"
 
 [dependencies.noto-sans-mono-bitmap]
 version = "0.1.2"
 default-features = false
 features = ["regular", "size_14"]
-
-[patch.crates-io]
-# Change this to the revision of the bootloader you want to test.
-bootloader = { git = "https://github.com/rust-osdev/bootloader", branch = "next", package = "bootloader", version = "=0.11.0-alpha" }
-bootloader_api = { git = "https://github.com/rust-osdev/bootloader", branch = "next", package = "bootloader_api", version = "=0.1.0-alpha.0" }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.64"
-bootloader = "=0.11.0-alpha.0"
+bootloader = "=0.11.0-alpha"
 ovmf-prebuilt = "0.1.0-alpha.1"
 test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }
 
 [build-dependencies]
-bootloader = "=0.11.0-alpha.0"
+bootloader = "=0.11.0-alpha"
 test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.64"
-bootloader = "=0.11.0-alpha"
+bootloader = { git = "https://github.com/rust-osdev/bootloader", branch = "next" }
 ovmf-prebuilt = "0.1.0-alpha.1"
 test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }
 
 [build-dependencies]
-bootloader = "=0.11.0-alpha"
 test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -3,13 +3,17 @@ use std::process::Command;
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    let boot_partition_path = AsRef::as_ref("target/boot.fat");
-    bootloader::create_boot_partition(
-        AsRef::as_ref(env!("CARGO_BIN_FILE_TEST_KERNEL_test-kernel")),
-        boot_partition_path,
-    )?;
     let out_gpt_path = &AsRef::as_ref("target/uefi.img");
-    bootloader::create_uefi_disk_image(boot_partition_path, out_gpt_path)?;
+    bootloader::UefiBoot::new(AsRef::as_ref(env!(
+        "CARGO_BIN_FILE_TEST_KERNEL_test-kernel"
+    )))
+    .create_disk_image(out_gpt_path)?;
+
+    let out_bios_path = &AsRef::as_ref("target/bios.img");
+    bootloader::BiosBoot::new(AsRef::as_ref(env!(
+        "CARGO_BIN_FILE_TEST_KERNEL_test-kernel"
+    )))
+    .create_disk_image(out_bios_path)?;
 
     let mut cmd = Command::new("qemu-system-x86_64");
     cmd.arg("-bios").arg(ovmf_prebuilt::ovmf_pure_efi());


### PR DESCRIPTION
Updates to the latest version in https://github.com/rust-osdev/bootloader/pull/232.

I changed the disk image creation API and apparently the version number since you created this test kernel.