### PR TITLE
Simplify build process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "bootloader_api",
  "noto-sans-mono-bitmap",
  "uart_16550",
+ "x86_64",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "autocfg"
@@ -180,14 +180,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -203,18 +202,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "llvm-tools"
@@ -270,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "ovmf-prebuilt"
@@ -282,9 +281,9 @@ checksum = "fa50141d081512ab30fd9e7e7692476866df5098b028536ad6680212e717fa8d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -329,7 +328,6 @@ dependencies = [
  "anyhow",
  "bootloader",
  "ovmf-prebuilt",
- "test-kernel",
 ]
 
 [[package]]
@@ -360,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -442,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "uuid"
@@ -475,9 +473,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -485,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -500,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -510,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ resolver = "2"
 [dependencies]
 bootloader_api = { git = "https://github.com/rust-osdev/bootloader", branch = "next" }
 uart_16550 = "0.2.10"
+x86_64 = "0.14"
 
 [dependencies.noto-sans-mono-bitmap]
 version = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ This repo implements a simple kernel that can be used for testing https://github
 
 ## Building an image
 
-Run this command to build an image and start it in qemu.
+Run this command will build the kernel, it's built on target `x86_64-unknown-none`, if you encounter error
+like target `x86_64-unknown-none` not installed, try run `rustup target add x86_64-unknown-none`
+
+```shell
+$ cargo build
+```
+
+Run this command to build an image and start it in qemu. Make sure you already have the test-kernel built.
+The default kernel path is `target/x86_64-unknown-none/debug/test-kernel`, if the file not exists, try build
+it, if the kernel is anywhere else, try set `KERNEL_PATH` environment variable.
 
 ```shell
 $ cargo run -p runner
 ```
 
-The image will be placed in `target/uefi.img` and can be flashed onto a USB flash drive for testing with real hardware.
+This command will prepend a bootloader to the kernel and generate a disk image at `target/uefi.img`.
+This image can be tested on qemu or can be flashed onto a USB flash drive for testing with real hardware.
 
 ## Expected output
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The test kernel will do the following things:
 - Log the bootloader version
 - Log the offset of the physical memory mapping created by the bootloader
 - Log the memory map provided by the bootloader
+- Log the current CMOS time
 - Attempt to write all usable memory to check if the memory map is correct
 
 Last but not least, the test kernel will log "Done". If this message isn't logged one of the tests caused a crash.

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -9,7 +9,3 @@ edition = "2021"
 anyhow = "1.0.64"
 bootloader = { git = "https://github.com/rust-osdev/bootloader", branch = "next" }
 ovmf-prebuilt = "0.1.0-alpha.1"
-test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }
-
-[build-dependencies]
-test-kernel = { path = "..", artifact = "bin", target = "x86_64-unknown-none" }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,19 +1,15 @@
+use anyhow::Result;
+use std::env;
 use std::process::Command;
 
-use anyhow::Result;
-
 fn main() -> Result<()> {
+    let kernel_path = env::var("KERNEL_PATH")
+        .unwrap_or(String::from("target/x86_64-unknown-none/debug/test-kernel"));
     let out_gpt_path = &AsRef::as_ref("target/uefi.img");
-    bootloader::UefiBoot::new(AsRef::as_ref(env!(
-        "CARGO_BIN_FILE_TEST_KERNEL_test-kernel"
-    )))
-    .create_disk_image(out_gpt_path)?;
+    bootloader::UefiBoot::new(AsRef::as_ref(&kernel_path)).create_disk_image(out_gpt_path)?;
 
     let out_bios_path = &AsRef::as_ref("target/bios.img");
-    bootloader::BiosBoot::new(AsRef::as_ref(env!(
-        "CARGO_BIN_FILE_TEST_KERNEL_test-kernel"
-    )))
-    .create_disk_image(out_bios_path)?;
+    bootloader::BiosBoot::new(AsRef::as_ref(&kernel_path)).create_disk_image(out_bios_path)?;
 
     let mut cmd = Command::new("qemu-system-x86_64");
     cmd.arg("-bios").arg(ovmf_prebuilt::ovmf_pure_efi());

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use logger::{log, Color};
 
 mod graphical;
 mod logger;
+mod time;
 
 const CONFIG: BootloaderConfig = {
     let mut config = BootloaderConfig::new_default();
@@ -98,6 +99,15 @@ fn main(boot_info: &'static mut BootInfo) -> ! {
             core::ptr::write_bytes(addr as *mut u8, 0xff, size as usize);
         }
     }
+
+    let now = time::now();
+    log(
+        format_args!(
+            "current time: {}-{}-{} {}:{}:{}, centry: {}",
+            now.year, now.month, now.day, now.hour, now.minute, now.second, now.century
+        ),
+        Color::White,
+    );
 
     log("Done!", Color::White);
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,133 @@
+//! "CMOS" is a tiny bit of very low power static memory that lives on the same chip as the Real-Time Clock (RTC)
+//! Implementation mostly copied from https://github.com/deadblackclover/CMOS/blob/main/src/lib.rs
+//! CMOS port and register config see: https://wiki.osdev.org/CMOS
+
+use x86_64::instructions::port::Port;
+
+/// Selecting a CMOS register port
+const CMOS_ADDRESS: u16 = 0x70;
+
+/// Data receiving port
+const CMOS_DATA: u16 = 0x71;
+
+/// Struct for storage time
+pub struct Time {
+    pub second: u8,
+    pub minute: u8,
+    pub hour: u8,
+    pub day: u8,
+    pub month: u8,
+    pub year: u16,
+    pub century: u8,
+}
+
+/// Struct for storage ports, current year and century register
+struct ReadRTC {
+    cmos_address: Port<u8>,
+    cmos_data: Port<u8>,
+    century_register: u8,
+}
+
+impl ReadRTC {
+    /// Creates a new `ReadRTC`.
+    const fn new(century_register: u8) -> ReadRTC {
+        ReadRTC {
+            cmos_address: Port::new(CMOS_ADDRESS),
+            cmos_data: Port::new(CMOS_DATA),
+            century_register,
+        }
+    }
+
+    /// Lets you know if a time update is in progress
+    fn get_update_in_progress_flag(&mut self) -> u8 {
+        unsafe {
+            self.cmos_address.write(0x0A);
+            self.cmos_data.read() & 0x80
+        }
+    }
+
+    /// Retrieves a value from a time register
+    fn get_rtc_register(&mut self, reg: u8) -> u8 {
+        unsafe {
+            self.cmos_address.write(reg);
+            self.cmos_data.read()
+        }
+    }
+
+    /// Updating our time
+    fn update_time(&mut self) -> Time {
+        // Make sure an update isn't in progress
+        while self.get_update_in_progress_flag() != 0 {}
+        Time {
+            second: self.get_rtc_register(0x00),
+            minute: self.get_rtc_register(0x02),
+            hour: self.get_rtc_register(0x04),
+            day: self.get_rtc_register(0x07),
+            month: self.get_rtc_register(0x08),
+            year: self.get_rtc_register(0x09) as u16,
+            century: if self.century_register != 0 {
+                self.get_rtc_register(self.century_register)
+            } else {
+                0
+            },
+        }
+    }
+
+    /// Gets the time without regard to the time zone
+    fn read(&mut self) -> Time {
+        let mut last_time: Time;
+        let mut time: Time = self.update_time();
+
+        loop {
+            last_time = time;
+            time = self.update_time();
+
+            if (last_time.second == time.second)
+                && (last_time.minute == time.minute)
+                && (last_time.hour == time.hour)
+                && (last_time.day == time.day)
+                && (last_time.month == time.month)
+                && (last_time.year == time.year)
+                && (last_time.century == time.century)
+            {
+                break;
+            }
+        }
+
+        let register_b = self.get_rtc_register(0x0B);
+
+        if !(register_b & 0x04 != 0) {
+            time.second = (time.second & 0x0F) + ((time.second / 16) * 10);
+            time.minute = (time.minute & 0x0F) + ((time.minute / 16) * 10);
+            time.hour =
+                ((time.hour & 0x0F) + (((time.hour & 0x70) / 16) * 10)) | (time.hour & 0x80);
+            time.day = (time.day & 0x0F) + ((time.day / 16) * 10);
+            time.month = (time.month & 0x0F) + ((time.month / 16) * 10);
+            time.year = (time.year & 0x0F) + ((time.year / 16) * 10);
+            if self.century_register != 0 {
+                time.century = (time.century & 0x0F) + ((time.century / 16) * 10);
+            }
+        }
+
+        // Convert 12 hour clock to 24 hour clock
+
+        if !(register_b & 0x02 != 0) && (time.hour & 0x80 != 0) {
+            time.hour = ((time.hour & 0x7F) + 12) % 24;
+        }
+
+        // Calculate the full (4-digit) year
+
+        if self.century_register != 0 {
+            time.year += (time.century as u16) * 100;
+        } else {
+            time.year += 2000;
+        }
+
+        time
+    }
+}
+
+pub fn now() -> Time {
+    let mut cmos = ReadRTC::new(0x32);
+    cmos.read()
+}


### PR DESCRIPTION
1. Seperate kernel code and runner. 
Runner doesn't depends on source code of `test-kernel`, so no need to specify it in `Cargo.toml`. Also the kernel artifact path is like `target/x86_64-unknown-none/debug/deps/artifact/test-kernel-e83f95b885bce50e/bin/test_kernel-e83f95b885bce50e` which is not always updated on rebuild, so better to use `target/x86_64-unknown-none/debug/test-kernel` directly.
2. Add basic time support.